### PR TITLE
Fixing shift operation to use unsigned int for go version go1.12.7 

### DIFF
--- a/filters/aes.go
+++ b/filters/aes.go
@@ -77,7 +77,7 @@ func (km *keyManager) stretch(salt, password []byte) []byte {
 
 func (km *keyManager) sha256Stretch(power int, salt, password []byte) []byte {
 	var temp [8]byte
-	for round := 0; round < 1<<power; round++ {
+	for round := 0; round < 1<<uint(power); round++ {
 		km.hasher.Write(salt)
 		km.hasher.Write(password)
 		km.hasher.Write(temp[:])

--- a/reader.go
+++ b/reader.go
@@ -9,7 +9,7 @@ import (
 	"os"
 	"sync"
 
-	"github.com/saracen/go7z/headers"
+	"github.com/francisco-alanis/go7z/headers"
 	"github.com/saracen/solidblock"
 )
 

--- a/reader_test.go
+++ b/reader_test.go
@@ -4,8 +4,6 @@ import (
 	"io"
 	"io/ioutil"
 	"testing"
-
-	"github.com/saracen/go7z-fixtures"
 )
 
 func TestOpenReader(t *testing.T) {

--- a/register.go
+++ b/register.go
@@ -8,7 +8,7 @@ import (
 	"io"
 	"sync"
 
-	"github.com/saracen/go7z/filters"
+	"github.com/francisco-alanis/go7z/filters"
 	"github.com/ulikunitz/xz/lzma"
 )
 


### PR DESCRIPTION
windows/amd64