### PR TITLE
Fix error on Next() when skipping files.

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"hash/crc32"
 	"io"
+	"io/ioutil"
 	"os"
 	"sync"
 
@@ -344,6 +345,14 @@ func (sz *Reader) next() (*headers.FileInfo, error) {
 	sz.emptyStream = fileInfo.IsEmptyStream
 	if sz.emptyStream {
 		return fileInfo, nil
+	}
+
+	if sz.folders[sz.folderIndex].sb != nil {
+		// Discard remainig bytes for current file.
+		// TODO: we should check if the underlying reader supports Seek to improve performance when possible.
+		if _, err := io.Copy(ioutil.Discard, sz.folders[sz.folderIndex].sb); err != nil {
+			return nil, err
+		}
 	}
 
 	if sz.folders[sz.folderIndex].Next() == io.EOF {

--- a/reader_test.go
+++ b/reader_test.go
@@ -5,7 +5,7 @@ import (
 	"io/ioutil"
 	"testing"
 
-	"github.com/saracen/go7z-fixtures"
+	fixtures "github.com/saracen/go7z-fixtures"
 )
 
 func TestOpenReader(t *testing.T) {
@@ -62,6 +62,42 @@ func TestReader(t *testing.T) {
 			}
 			if err != nil {
 				panic(err)
+			}
+
+			if _, err = io.Copy(ioutil.Discard, sz); err != nil {
+				t.Fatal(err)
+			}
+			count++
+		}
+
+		if count != f.Entries {
+			t.Fatalf("expected %v entries, got %v\n", f.Entries, count)
+		}
+	}
+}
+
+func TestSkipFile(t *testing.T) {
+	fs, closeall := fixtures.Fixtures([]string{"executable", "random"}, []string{})
+	defer closeall.Close()
+	for _, f := range fs {
+		sz, err := NewReader(f, f.Size)
+		if err != nil {
+			t.Fatalf("error reading %v: %v\n", f.Archive, err)
+		}
+
+		count := 0
+		for {
+			_, err := sz.Next()
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if count%2 == 0 {
+				count++
+				continue
 			}
 
 			if _, err = io.Copy(ioutil.Discard, sz); err != nil {


### PR DESCRIPTION
With this change, we discard remaining bytes for the actual file to
avoid errors on partial reads or skipping files calling Next()
without reading.

Several optimizations are possible, like directly Seek to the next file
without reading the previous one, if the underlying reader supports it.

Signed-off-by: Antonio Navarro Perez <antnavper@gmail.com>